### PR TITLE
Read lock used

### DIFF
--- a/interactor/borrow_return.go
+++ b/interactor/borrow_return.go
@@ -5,13 +5,11 @@ import (
 	"github.com/sfqi/library/domain/model"
 )
 
-
 type newLoan interface {
 	CreateLoan(*model.Loan) error
 	FindBookById(int) (*model.Book, error)
 	UpdateBook(*model.Book) error
 }
-
 
 type LoanWriter struct {
 	store     Store
@@ -30,14 +28,19 @@ func NewBookLoan(borrowReturn Store, generator uuidGenerator) *LoanWriter {
 }
 
 func (l *LoanWriter) Borrow(userID int, bookID int) (*model.Loan, error) {
-  tx := l.store.Transaction()
+	tx := l.store.Transaction()
 	uuid, err := l.generator.Do()
 	if err != nil {
 		tx.Rollback()
 		return nil, err
 	}
 
-	book, err := l.store.FindBookById(bookID)
+	book, err := l.store.FindByIdSelectUpdate(bookID)
+	if err != nil {
+		tx.Rollback()
+		return nil, errors.New("Error finding book")
+	}
+
 	if book.Available != true {
 		tx.Rollback()
 		return nil, errors.New("Book is not available")
@@ -63,7 +66,7 @@ func (l *LoanWriter) Borrow(userID int, bookID int) (*model.Loan, error) {
 }
 
 func (l *LoanWriter) Return(userID int, bookID int) (*model.Loan, error) {
-  tx := l.store.Transaction()
+	tx := l.store.Transaction()
 	uuid, err := l.generator.Do()
 	if err != nil {
 		tx.Rollback()

--- a/interactor/borrow_return.go
+++ b/interactor/borrow_return.go
@@ -5,12 +5,6 @@ import (
 	"github.com/sfqi/library/domain/model"
 )
 
-type newLoan interface {
-	CreateLoan(*model.Loan) error
-	FindBookById(int) (*model.Book, error)
-	UpdateBook(*model.Book) error
-}
-
 type LoanWriter struct {
 	store     Store
 	generator uuidGenerator
@@ -35,7 +29,7 @@ func (l *LoanWriter) Borrow(userID int, bookID int) (*model.Loan, error) {
 		return nil, err
 	}
 
-	book, err := l.store.FindByIdSelectUpdate(bookID)
+	book, err := l.store.FindBookByIDForUpdate(bookID)
 	if err != nil {
 		tx.Rollback()
 		return nil, errors.New("Error finding book")

--- a/interactor/borrow_return_test.go
+++ b/interactor/borrow_return_test.go
@@ -18,7 +18,7 @@ func TestBorrow(t *testing.T) {
 
 		bookInUse := &model.Book{Id: 1, Available: true}
 		store.On("Transaction").Return(store)
-		store.On("FindBookById", 1).Return(bookInUse, nil)
+		store.On("FindBookByIDForUpdate", 1).Return(bookInUse, nil)
 		store.On("UpdateBook", bookInUse).Return(nil)
 		store.On("Commit").Return(nil)
 		loan := model.BorrowedLoan(1, 1, "gen123-gen321")
@@ -40,7 +40,7 @@ func TestBorrow(t *testing.T) {
 		bookInUse := &model.Book{Id: 1, Available: false}
 
 		store.On("Transaction").Return(store)
-		store.On("FindBookById", 1).Return(bookInUse, nil)
+		store.On("FindBookByIDForUpdate", 1).Return(bookInUse, nil)
 		store.On("Rollback")
 		generator.On("Do").Return("gen123-gen321", nil)
 
@@ -58,7 +58,7 @@ func TestBorrow(t *testing.T) {
 		bookInUse := &model.Book{Id: 1, Available: true}
 
 		store.On("Transaction").Return(store)
-		store.On("FindBookById", 1).Return(bookInUse, nil)
+		store.On("FindBookByIDForUpdate", 1).Return(bookInUse, nil)
 		store.On("UpdateBook", bookInUse).Return(nil)
 		store.On("Rollback")
 		loan := model.BorrowedLoan(1, 1, "gen123-gen321")

--- a/interactor/store.go
+++ b/interactor/store.go
@@ -16,4 +16,5 @@ type Store interface {
 	Transaction() Store
 	Commit() error
 	Rollback()
+	FindByIdSelectUpdate(int) (*model.Book, error)
 }

--- a/interactor/store.go
+++ b/interactor/store.go
@@ -16,5 +16,5 @@ type Store interface {
 	Transaction() Store
 	Commit() error
 	Rollback()
-	FindByIdSelectUpdate(int) (*model.Book, error)
+	FindBookByIDForUpdate(int) (*model.Book, error)
 }

--- a/repository/mock/store.go
+++ b/repository/mock/store.go
@@ -110,3 +110,12 @@ func (s *Store) Commit() error {
 func (s *Store) Rollback() {
 	s.Called()
 }
+
+func (s *Store) FindBookByIDForUpdate(id int) (*model.Book, error) {
+	args := s.Called(id)
+	if args.Get(0) != nil {
+		return args.Get(0).(*model.Book), nil
+	}
+
+	return nil, args.Error(1)
+}

--- a/repository/postgres/postgres.go
+++ b/repository/postgres/postgres.go
@@ -135,9 +135,9 @@ func (store *Store) Rollback() {
 	store.db.Rollback()
 }
 
-func (store *Store) FindByIdSelectUpdate(bookID int) (*model.Book, error) {
+func (store *Store) FindBookByIDForUpdate(id int) (*model.Book, error) {
 	var book model.Book
-	if err := store.db.Set("gorm:query_option", "FOR UPDATE").First(&model.Book{}, bookID).Scan(&book).Error; err != nil {
+	if err := store.db.Set("gorm:query_option", "FOR UPDATE").First(&book, id).Error; err != nil {
 		return nil, err
 	}
 	return &book, nil

--- a/repository/postgres/postgres.go
+++ b/repository/postgres/postgres.go
@@ -134,3 +134,11 @@ func (store *Store) Commit() error {
 func (store *Store) Rollback() {
 	store.db.Rollback()
 }
+
+func (store *Store) FindByIdSelectUpdate(bookID int) (*model.Book, error) {
+	var book model.Book
+	if err := store.db.Set("gorm:query_option", "FOR UPDATE").First(&model.Book{}, bookID).Scan(&book).Error; err != nil {
+		return nil, err
+	}
+	return &book, nil
+}


### PR DESCRIPTION
What are we doing here, is adding one more method against postgres 'FindBookByIDForUpdate' . We are doing this so we can avoid non-consistent reading from data base. If we get 2 request for borrowing book at a same time, both of them can pass, and we want to avoid that.
If we have 2 threads hitting the same endpoint, if 1 thread has a read lock on a row/table, no thread can update/insert/delete data from that table. The write transaction should wait for read locks to finish reading.